### PR TITLE
hunter update + eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ include("cmake/HunterGate.cmake")
 option(DEST_BUILD_EXAMPLES "Build DEST examples." OFF)
 option(DEST_WITH_OPENCV "Build DEST with OpenCV support." OFF)
 
-set(HUNTER_DEST_URL "https://github.com/ruslo/hunter/archive/v0.14.19.tar.gz")
-set(HUNTER_DEST_SHA1 "ab886ddc6be6870a403224ee8f587e640827b1d9")
+set(HUNTER_DEST_URL "https://github.com/ruslo/hunter/archive/v0.18.9.tar.gz")
+set(HUNTER_DEST_SHA1 "90bf10e2895531145332a8963725a351d7345c58")
 
 if(DEST_WITH_OPENCV)
   HunterGate(
@@ -26,20 +26,13 @@ endif()
 
 project(deformable-shape-tracking VERSION 0.8.0)
 
-if (WIN32)
-  add_definitions("-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-endif()
-
 set(DEST_LINK_TARGETS)
 
 option(DEST_BUILD_TESTS "Build tests." OFF)
 
 ### Eigen3 (Header only)
 hunter_add_package(Eigen)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ### flatbuffers (header only)
 hunter_add_package(flatbuffers)
@@ -54,6 +47,10 @@ if(DEST_WITH_OPENCV)
   include_directories(${OpenCV_INCLUDE_DIRS})
   list(APPEND DEST_LINK_TARGETS ${OpenCV_LIBRARIES})
   message(STATUS "Compiling with OpenCV support")
+
+  hunter_add_package(tinydir)
+  find_package(tinydir REQUIRED)
+  list(APPEND DEST_LINK_TARGETS tinydir::tinydir)
 
 else()
   message(STATUS "Compiling without OpenCV support")
@@ -124,7 +121,17 @@ if(DEST_WITH_OPENCV)
 endif(DEST_WITH_OPENCV)
 
 add_library(dest ${DEST_SOURCES})
-target_link_libraries(dest PUBLIC ${DEST_LINK_TARGETS} Eigen::eigen flatbuffers::flatbuffers)
+target_link_libraries(dest PUBLIC ${DEST_LINK_TARGETS} Eigen3::Eigen flatbuffers::flatbuffers)
+
+if(HUNTER_ENABLED AND DEST_WITH_OPENCV)
+  target_compile_definitions(dest PRIVATE DEST_INTERNAL_TINYDIR=0)
+else()
+  target_compile_definitions(dest PRIVATE DEST_INTERNAL_TINYDIR=1)
+endif()
+
+if (WIN32)
+  target_compile_definitions(dest PUBLIC _SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_WARNINGS)
+endif()
 
 # Samples
 if(DEST_WITH_OPENCV AND DEST_BUILD_EXAMPLES)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,10 +1,11 @@
 @PACKAGE_INIT@
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(flatbuffers CONFIG REQUIRED)
 
 if(@DEST_WITH_OPENCV@)
   find_package(OpenCV REQUIRED)
+  find_package(tinydir CONFIG REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -22,7 +22,7 @@ set(OPENCV_CMAKE_ARGS
   WITH_PTHREADS_PF=OFF    # "Use pthreads-based parallel_for"
   WITH_TBB=OFF            # "Include Intel TBB support"
   WITH_1394=OFF           # "Include IEEE1394 support"
-  WITH_AVFOUNDATION=OFF   # "Use AVFoundation for Video I/O"
+  WITH_AVFOUNDATION=ON    # "Use AVFoundation for Video I/O"
   WITH_CARBON=OFF         # "Use Carbon for UI instead of Cocoa"
   WITH_VTK=OFF            # "Include VTK library support (and build opencv_viz module eiher)"
   WITH_CUDA=OFF           # "Include NVidia Cuda Runtime support"
@@ -66,6 +66,13 @@ set(OPENCV_CMAKE_ARGS
   WITH_IPP_A=OFF          # "Include Intel IPP_A support"
   WITH_GDAL=OFF           # "Include GDAL Support"
   WITH_GPHOTO2=OFF        # "Include gPhoto2 library support"
+
+  WITH_QTKIT=OFF
   )
 
-hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+if(APPLE)
+  # Fixes #include <QTKit/QTKit.h> failure on >= OS X 10.12
+  hunter_config(OpenCV VERSION 3.0.0-p11 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+else()
+  hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+endif()

--- a/src/util/glob.cpp
+++ b/src/util/glob.cpp
@@ -9,7 +9,12 @@
 */
 
 #include <dest/util/glob.h>
-#include <tinydir/tinydir.h>
+
+#if DEST_INTERNAL_TINYDIR
+#  include <tinydir/tinydir.h>
+#else
+#  include <tinydir.h>
+#endif
 #include <stack>
 #include <algorithm>
 


### PR DESCRIPTION
update hunter version
* Eigen -> Eigen3 : find_package(Eigen3)
* Hunter -> v0.18.9
* remove hard coded CMAKE_CXX_FLAGS “-std=c++11” (should be set in toolchain)
* use target_compile_definitions()  for MSVC settings (not add_definitions)
* add missing tinydir package when DEST_WITH_OPENCV=ON
* add workaround for missing QTKit.h OPENCV build error on >= 10.12 (this only impacts local builds for APPLE, since opencv configurations will defer to the parent project hunter configuration…)